### PR TITLE
Add Playwright MCP chatbot demo

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,1 +1,44 @@
-# Autonomous
+# Playwright MCP Chatbot Demo
+
+This project demonstrates how a Model Context Protocol (MCP) server powered by Playwright can pair
+with an AI SDK UI chatbot interface. The UI showcases a cards-based documentation navigator and a
+chat panel that simulates deterministic tool usage with Playwright.
+
+## Getting started
+
+```bash
+npm install
+npm run dev
+```
+
+The development server runs on [http://localhost:5173](http://localhost:5173).
+
+## Available scripts
+
+- `npm run dev` – start the Vite development server
+- `npm run build` – type-check and create a production build
+- `npm run preview` – preview the built app locally
+
+## Project structure
+
+```
+.
+├── index.html
+├── package.json
+├── src
+│   ├── App.tsx
+│   ├── components
+│   │   ├── Chatbot.tsx
+│   │   └── IndexCards.tsx
+│   ├── main.tsx
+│   └── styles.css
+├── tsconfig.json
+├── tsconfig.node.json
+└── vite.config.ts
+```
+
+## Next steps
+
+Replace the simulated assistant responses inside `Chatbot.tsx` with live streaming data from your MCP
+server. The UI is intentionally framework-agnostic so it can connect to any backend that emits AI SDK
+UI-compatible message streams.

--- a/index.html
+++ b/index.html
@@ -1,0 +1,12 @@
+<!doctype html>
+<html lang="en">
+  <head>
+    <meta charset="UTF-8" />
+    <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+    <title>Playwright MCP Chatbot</title>
+  </head>
+  <body>
+    <div id="root"></div>
+    <script type="module" src="/src/main.tsx"></script>
+  </body>
+</html>

--- a/package.json
+++ b/package.json
@@ -1,0 +1,22 @@
+{
+  "name": "playwright-mcp-chatbot",
+  "version": "0.1.0",
+  "private": true,
+  "type": "module",
+  "scripts": {
+    "dev": "vite",
+    "build": "tsc && vite build",
+    "preview": "vite preview"
+  },
+  "dependencies": {
+    "react": "^18.3.1",
+    "react-dom": "^18.3.1"
+  },
+  "devDependencies": {
+    "@types/react": "^18.3.5",
+    "@types/react-dom": "^18.3.0",
+    "@vitejs/plugin-react": "^4.3.1",
+    "typescript": "^5.4.5",
+    "vite": "^5.2.11"
+  }
+}

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -1,0 +1,71 @@
+import { Chatbot } from './components/Chatbot';
+import { IndexCards } from './components/IndexCards';
+
+export default function App() {
+  return (
+    <main>
+      <section>
+        <h1>Playwright MCP + AI SDK UI</h1>
+        <p className="lead">
+          Explore how a Model Context Protocol server powered by Playwright can collaborate with
+          an AI SDK UI chatbot for deterministic browser automation workflows.
+        </p>
+        <IndexCards
+          cards={[
+            {
+              title: 'Overview',
+              description: 'Get an overview about the AI SDK UI.',
+              href: '/docs/ai-sdk-ui/overview'
+            },
+            {
+              title: 'Chatbot',
+              description: 'Learn how to integrate an interface for a chatbot.',
+              href: '/docs/ai-sdk-ui/chatbot'
+            },
+            {
+              title: 'Chatbot Message Persistence',
+              description: 'Learn how to store and load chat messages in a chatbot.',
+              href: '/docs/ai-sdk-ui/chatbot-message-persistence'
+            },
+            {
+              title: 'Chatbot Tool Usage',
+              description: 'Learn how to integrate an interface for a chatbot with tool calling.',
+              href: '/docs/ai-sdk-ui/chatbot-tool-usage'
+            },
+            {
+              title: 'Completion',
+              description: 'Learn how to integrate an interface for text completion.',
+              href: '/docs/ai-sdk-ui/completion'
+            },
+            {
+              title: 'Object Generation',
+              description: 'Learn how to integrate an interface for object generation.',
+              href: '/docs/ai-sdk-ui/object-generation'
+            },
+            {
+              title: 'Streaming Data',
+              description: 'Learn how to stream data.',
+              href: '/docs/ai-sdk-ui/streaming-data'
+            },
+            {
+              title: 'Reading UI Message Streams',
+              description:
+                'Learn how to read UIMessage streams for terminal UIs, custom clients, and server components.',
+              href: '/docs/ai-sdk-ui/reading-ui-message-streams'
+            },
+            {
+              title: 'Error Handling',
+              description: 'Learn how to handle errors.',
+              href: '/docs/ai-sdk-ui/error-handling'
+            }
+          ]}
+        />
+      </section>
+
+      <section className="chat-layout">
+        <h2 className="section-title">Chatbot Demo</h2>
+        <Chatbot />
+      </section>
+    </main>
+  );
+}

--- a/src/components/Chatbot.tsx
+++ b/src/components/Chatbot.tsx
@@ -1,0 +1,152 @@
+import { useMemo, useState } from 'react';
+
+type MessageRole = 'user' | 'assistant' | 'tool';
+
+type Message = {
+  id: string;
+  role: MessageRole;
+  name?: string;
+  content: string;
+  toolCall?: {
+    name: string;
+    args: Record<string, unknown>;
+    result?: string;
+  };
+};
+
+const seedMessages: Message[] = [
+  {
+    id: '1',
+    role: 'assistant',
+    name: 'Playwright MCP',
+    content:
+      "Hello! I can drive Playwright to collect structured accessibility snapshots so you don't have to parse screenshots. What workflow should we run today?"
+  },
+  {
+    id: '2',
+    role: 'user',
+    name: 'You',
+    content: 'Navigate to the AI SDK UI chatbot docs and summarise the integration steps.'
+  },
+  {
+    id: '3',
+    role: 'assistant',
+    name: 'Playwright MCP',
+    content: 'Running Playwright navigation…',
+    toolCall: {
+      name: 'playwright.navigate',
+      args: { url: 'https://sdk.vercel.ai/docs/ai-sdk-ui/chatbot' },
+      result: 'Visited documentation page and captured accessibility tree.'
+    }
+  },
+  {
+    id: '4',
+    role: 'assistant',
+    name: 'Playwright MCP',
+    content:
+      'The docs recommend rendering the <Chat /> component, wiring a message array, and streaming responses through the AI SDK UI channel APIs.'
+  }
+];
+
+export function Chatbot() {
+  const [messages, setMessages] = useState(seedMessages);
+  const [input, setInput] = useState('');
+
+  const placeholder = useMemo(
+    () =>
+      'Ask the MCP server to explore, capture snapshots, or execute deterministic browser actions…',
+    []
+  );
+
+  function handleSubmit(event: React.FormEvent<HTMLFormElement>) {
+    event.preventDefault();
+    if (!input.trim()) {
+      return;
+    }
+
+    const userMessage: Message = {
+      id: `${Date.now()}`,
+      role: 'user',
+      name: 'You',
+      content: input.trim()
+    };
+
+    const assistantMessage: Message = {
+      id: `${Date.now()}-assistant`,
+      role: 'assistant',
+      name: 'Playwright MCP',
+      content:
+        'This demo response is simulated. Hook this UI to your MCP server stream to make it conversational!'
+    };
+
+    setMessages((prev) => [...prev, userMessage, assistantMessage]);
+    setInput('');
+  }
+
+  return (
+    <div className="chat-panel">
+      <header className="chat-header">
+        <div className="avatar avatar-assistant">M</div>
+        <div>
+          <div className="chat-title">Model Context Protocol Chat</div>
+          <p className="chat-description">
+            Showcase of an AI SDK UI chatbot panel wired for deterministic tool usage with Playwright.
+          </p>
+        </div>
+      </header>
+
+      <div className="chat-messages" aria-live="polite">
+        {messages.map((message) => (
+          <ChatMessage key={message.id} message={message} />
+        ))}
+      </div>
+
+      <form className="chat-input" onSubmit={handleSubmit}>
+        <textarea
+          aria-label="Chat message"
+          value={input}
+          placeholder={placeholder}
+          onChange={(event) => setInput(event.target.value)}
+        />
+        <button type="submit">Send</button>
+      </form>
+    </div>
+  );
+}
+
+type ChatMessageProps = {
+  message: Message;
+};
+
+function ChatMessage({ message }: ChatMessageProps) {
+  const isUser = message.role === 'user';
+  const avatarClass = isUser ? 'avatar avatar-user' : 'avatar avatar-assistant';
+  const avatarLabel = isUser ? 'You' : message.name ?? 'Assistant';
+
+  return (
+    <article className="message">
+      <div className={avatarClass} aria-hidden="true">
+        {avatarLabel.slice(0, 1)}
+      </div>
+      <div className="message-body">
+        <header>{avatarLabel}</header>
+        <p>{message.content}</p>
+        {message.toolCall ? (
+          <pre className="tool-call">
+            <code>
+              {JSON.stringify(
+                {
+                  tool: message.toolCall.name,
+                  args: message.toolCall.args,
+                  result: message.toolCall.result
+                },
+                null,
+                2
+              )}
+            </code>
+          </pre>
+        ) : null}
+      </div>
+    </article>
+  );
+}

--- a/src/components/IndexCards.tsx
+++ b/src/components/IndexCards.tsx
@@ -1,0 +1,28 @@
+import type { ReactNode } from 'react';
+
+type IndexCard = {
+  title: string;
+  description: string;
+  href: string;
+  actionLabel?: ReactNode;
+};
+
+type IndexCardsProps = {
+  cards: IndexCard[];
+};
+
+export function IndexCards({ cards }: IndexCardsProps) {
+  return (
+    <div className="grid" role="list">
+      {cards.map((card) => (
+        <article key={card.href} className="card" role="listitem">
+          <h3>{card.title}</h3>
+          <p>{card.description}</p>
+          <a href={card.href} aria-label={`Read more about ${card.title}`}>
+            {card.actionLabel ?? 'Read the guide'}
+          </a>
+        </article>
+      ))}
+    </div>
+  );
+}

--- a/src/main.tsx
+++ b/src/main.tsx
@@ -1,0 +1,10 @@
+import React from 'react';
+import ReactDOM from 'react-dom/client';
+import App from './App';
+import './styles.css';
+
+ReactDOM.createRoot(document.getElementById('root') as HTMLElement).render(
+  <React.StrictMode>
+    <App />
+  </React.StrictMode>
+);

--- a/src/styles.css
+++ b/src/styles.css
@@ -1,0 +1,227 @@
+:root {
+  color-scheme: light dark;
+  font-family: 'Inter', system-ui, -apple-system, BlinkMacSystemFont, 'Segoe UI', sans-serif;
+  line-height: 1.6;
+  font-weight: 400;
+  color: #0f172a;
+  background-color: #f8fafc;
+}
+
+* {
+  box-sizing: border-box;
+}
+
+body {
+  margin: 0;
+  min-height: 100vh;
+  background: linear-gradient(180deg, #f1f5f9 0%, #ffffff 100%);
+}
+
+a {
+  color: inherit;
+}
+
+main {
+  max-width: 1080px;
+  margin: 0 auto;
+  padding: 3rem 1.5rem 4rem;
+}
+
+h1 {
+  font-size: clamp(2rem, 5vw, 3rem);
+  margin-bottom: 0.75rem;
+  font-weight: 700;
+  color: #0f172a;
+}
+
+.lead {
+  font-size: 1.125rem;
+  color: #475569;
+  margin-bottom: 2.5rem;
+}
+
+.grid {
+  display: grid;
+  gap: 1.5rem;
+}
+
+@media (min-width: 768px) {
+  .grid {
+    grid-template-columns: repeat(2, minmax(0, 1fr));
+  }
+}
+
+@media (min-width: 1024px) {
+  .grid {
+    grid-template-columns: repeat(3, minmax(0, 1fr));
+  }
+}
+
+.section-title {
+  font-size: 1.5rem;
+  margin-top: 3rem;
+  margin-bottom: 1rem;
+  color: #0f172a;
+}
+
+.card {
+  background: #ffffff;
+  border-radius: 1rem;
+  padding: 1.5rem;
+  box-shadow: 0 16px 32px -24px rgba(15, 23, 42, 0.4);
+  border: 1px solid rgba(15, 23, 42, 0.05);
+  transition: transform 160ms ease, box-shadow 160ms ease;
+}
+
+.card:hover {
+  transform: translateY(-4px);
+  box-shadow: 0 24px 40px -24px rgba(15, 23, 42, 0.3);
+}
+
+.card h3 {
+  margin: 0 0 0.5rem;
+  font-size: 1.125rem;
+  color: #0f172a;
+}
+
+.card p {
+  margin: 0 0 1rem;
+  color: #475569;
+}
+
+.card a {
+  font-weight: 600;
+  text-decoration: none;
+  color: #2563eb;
+}
+
+.chat-layout {
+  margin-top: 3rem;
+  display: grid;
+  gap: 1.5rem;
+}
+
+.chat-panel {
+  background: rgba(15, 23, 42, 0.02);
+  border-radius: 1.5rem;
+  padding: 1.5rem;
+  border: 1px solid rgba(15, 23, 42, 0.05);
+  display: flex;
+  flex-direction: column;
+  min-height: 480px;
+}
+
+.chat-header {
+  display: flex;
+  align-items: center;
+  gap: 0.75rem;
+  margin-bottom: 1rem;
+}
+
+.chat-title {
+  font-size: 1.25rem;
+  font-weight: 600;
+  color: #0f172a;
+}
+
+.chat-description {
+  color: #64748b;
+  font-size: 0.95rem;
+}
+
+.chat-messages {
+  flex: 1;
+  overflow-y: auto;
+  display: flex;
+  flex-direction: column;
+  gap: 1rem;
+  padding: 0.5rem 0;
+}
+
+.message {
+  display: flex;
+  gap: 0.75rem;
+  align-items: flex-start;
+}
+
+.avatar {
+  width: 40px;
+  height: 40px;
+  border-radius: 50%;
+  display: grid;
+  place-items: center;
+  font-weight: 600;
+  color: #fff;
+}
+
+.avatar-user {
+  background: #2563eb;
+}
+
+.avatar-assistant {
+  background: #0f172a;
+}
+
+.message-body {
+  background: #ffffff;
+  border-radius: 1rem;
+  padding: 1rem;
+  border: 1px solid rgba(15, 23, 42, 0.06);
+  box-shadow: 0 12px 24px -24px rgba(15, 23, 42, 0.5);
+  width: 100%;
+}
+
+.message-body header {
+  font-weight: 600;
+  margin-bottom: 0.35rem;
+  color: #0f172a;
+}
+
+.tool-call {
+  margin-top: 0.75rem;
+  padding: 0.75rem;
+  border-radius: 0.75rem;
+  background: rgba(37, 99, 235, 0.08);
+  border: 1px solid rgba(37, 99, 235, 0.18);
+  font-family: 'JetBrains Mono', 'SFMono-Regular', ui-monospace, SFMono-Regular, Menlo, Monaco, Consolas, 'Liberation Mono', 'Courier New', monospace;
+  font-size: 0.85rem;
+}
+
+.chat-input {
+  display: flex;
+  gap: 0.75rem;
+  margin-top: 1rem;
+}
+
+.chat-input textarea {
+  flex: 1;
+  resize: none;
+  padding: 0.9rem 1rem;
+  border-radius: 1rem;
+  border: 1px solid rgba(15, 23, 42, 0.15);
+  font: inherit;
+  min-height: 56px;
+  background: #fff;
+  box-shadow: inset 0 1px 2px rgba(15, 23, 42, 0.05);
+}
+
+.chat-input button {
+  padding: 0 1.5rem;
+  border-radius: 1rem;
+  border: none;
+  background: #2563eb;
+  color: #fff;
+  font-weight: 600;
+  cursor: pointer;
+  transition: background 150ms ease;
+}
+
+.chat-input button:hover {
+  background: #1d4ed8;
+}
+
+@media (max-width: 768px) {
+  .chat-panel {
+    min-height: 420px;
+  }
+}

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -1,0 +1,21 @@
+{
+  "compilerOptions": {
+    "target": "ES2020",
+    "useDefineForClassFields": true,
+    "module": "ESNext",
+    "lib": ["ES2020", "DOM", "DOM.Iterable"],
+    "skipLibCheck": true,
+    "moduleResolution": "Node",
+    "allowSyntheticDefaultImports": true,
+    "esModuleInterop": true,
+    "strict": true,
+    "forceConsistentCasingInFileNames": true,
+    "noFallthroughCasesInSwitch": true,
+    "resolveJsonModule": true,
+    "isolatedModules": true,
+    "noEmit": true,
+    "jsx": "react-jsx"
+  },
+  "include": ["src"],
+  "references": [{ "path": "./tsconfig.node.json" }]
+}

--- a/tsconfig.node.json
+++ b/tsconfig.node.json
@@ -1,0 +1,9 @@
+{
+  "compilerOptions": {
+    "composite": true,
+    "module": "ESNext",
+    "moduleResolution": "Node",
+    "allowSyntheticDefaultImports": true
+  },
+  "include": ["vite.config.ts"]
+}

--- a/vite.config.ts
+++ b/vite.config.ts
@@ -1,0 +1,10 @@
+import { defineConfig } from 'vite';
+import react from '@vitejs/plugin-react';
+
+export default defineConfig({
+  plugins: [react()],
+  server: {
+    host: '0.0.0.0',
+    port: 5173
+  }
+});


### PR DESCRIPTION
## Summary
- scaffold a Vite + React project for demonstrating a Playwright MCP chatbot interface
- implement documentation index cards and a simulated AI SDK UI chat panel highlighting tool usage
- add styling and configuration, including project documentation and build scripts

## Testing
- `npm install` *(fails: npm returned 403 Forbidden when attempting to download dependencies)*

------
https://chatgpt.com/codex/tasks/task_b_68e1a8112e348332be7b414e7f136c23