### PR TITLE
Build AI Elements landing content

### DIFF
--- a/src/App.tsx
+++ b/src/App.tsx
@@ -1,69 +1,101 @@
 import { Chatbot } from './components/Chatbot';
+import { ComponentList } from './components/ComponentList';
 import { IndexCards } from './components/IndexCards';
 
 export default function App() {
   return (
     <main>
-      <section>
-        <h1>Playwright MCP + AI SDK UI</h1>
+      <section className="hero">
+        <span className="eyebrow">Component Registry</span>
+        <h1>AI Elements</h1>
         <p className="lead">
-          Explore how a Model Context Protocol server powered by Playwright can collaborate with
-          an AI SDK UI chatbot for deterministic browser automation workflows.
+          AI Elements is a component library and custom registry built on top of shadcn/ui to help you
+          ship AI-native product experiences faster. Mix and match ready-to-use building blocks like
+          conversations, tasks, and inline citations without leaving your design system.
         </p>
+
+        <div className="hero-actions">
+          <a className="button" href="https://www.npmjs.com/package/ai-elements">
+            View on npm
+          </a>
+          <a className="button button-secondary" href="https://github.com/vercel/ai-elements">
+            Browse source code
+          </a>
+        </div>
+      </section>
+
+      <section className="installation">
+        <h2 className="section-title">Install in seconds</h2>
+        <p>
+          Use the Elements Installer CLI to scaffold the registry into your project. It wires up routes,
+          components, and styles that work with the shadcn/ui primitives you already rely on.
+        </p>
+        <pre>
+          <code>npx ai-elements init</code>
+        </pre>
+      </section>
+
+      <section>
+        <h2 className="section-title">Build production-ready AI workflows</h2>
         <IndexCards
           cards={[
             {
-              title: 'Overview',
-              description: 'Get an overview about the AI SDK UI.',
-              href: '/docs/ai-sdk-ui/overview'
-            },
-            {
-              title: 'Chatbot',
-              description: 'Learn how to integrate an interface for a chatbot.',
-              href: '/docs/ai-sdk-ui/chatbot'
-            },
-            {
-              title: 'Chatbot Message Persistence',
-              description: 'Learn how to store and load chat messages in a chatbot.',
-              href: '/docs/ai-sdk-ui/chatbot-message-persistence'
-            },
-            {
-              title: 'Chatbot Tool Usage',
-              description: 'Learn how to integrate an interface for a chatbot with tool calling.',
-              href: '/docs/ai-sdk-ui/chatbot-tool-usage'
-            },
-            {
-              title: 'Completion',
-              description: 'Learn how to integrate an interface for text completion.',
-              href: '/docs/ai-sdk-ui/completion'
-            },
-            {
-              title: 'Object Generation',
-              description: 'Learn how to integrate an interface for object generation.',
-              href: '/docs/ai-sdk-ui/object-generation'
-            },
-            {
-              title: 'Streaming Data',
-              description: 'Learn how to stream data.',
-              href: '/docs/ai-sdk-ui/streaming-data'
-            },
-            {
-              title: 'Reading UI Message Streams',
+              title: 'Opinionated building blocks',
               description:
-                'Learn how to read UIMessage streams for terminal UIs, custom clients, and server components.',
-              href: '/docs/ai-sdk-ui/reading-ui-message-streams'
+                'Start from accessible primitives for conversations, agent actions, tool responses, and more.',
+              href: 'https://ai-elements.vercel.app/components'
             },
             {
-              title: 'Error Handling',
-              description: 'Learn how to handle errors.',
-              href: '/docs/ai-sdk-ui/error-handling'
+              title: 'Stream-friendly by default',
+              description:
+                'Every component is wired for incremental rendering so you can plug into live model updates.',
+              href: 'https://ai-elements.vercel.app/guides/streaming'
+            },
+            {
+              title: 'Bring your data & design',
+              description:
+                'Extend tokens, swap icons, or hydrate from your existing state machines without rewriting UI.',
+              href: 'https://ai-elements.vercel.app/guides/theming'
             }
           ]}
         />
       </section>
 
+      <section className="catalogue">
+        <h2 className="section-title">Components included</h2>
+        <p className="catalogue-copy">
+          Ship the essentials for agentic experiences: status toasts for tools, task timelines, knowledge
+          sources, and more. Each entry links to interactive documentation so you can copy-paste examples
+          or pull the code directly from the registry.
+        </p>
+        <ComponentList
+          components={[
+            { name: 'Actions', path: 'actions' },
+            { name: 'Artifact', path: 'artifact' },
+            { name: 'Branch', path: 'branch' },
+            { name: 'Chain of Thought', path: 'chain-of-thought' },
+            { name: 'Code Block', path: 'code-block' },
+            { name: 'Context', path: 'context' },
+            { name: 'Conversation', path: 'conversation' },
+            { name: 'Image', path: 'image' },
+            { name: 'Loader', path: 'loader' },
+            { name: 'Message', path: 'message' },
+            { name: 'Open in Chat', path: 'open-in-chat' },
+            { name: 'Prompt Input', path: 'prompt-input' },
+            { name: 'Reasoning', path: 'reasoning' },
+            { name: 'Response', path: 'response' },
+            { name: 'Sources', path: 'sources' },
+            { name: 'Suggestion', path: 'suggestion' },
+            { name: 'Task', path: 'task' },
+            { name: 'Tool', path: 'tool' },
+            { name: 'Web Preview', path: 'web-preview' },
+            { name: 'Inline Citation', path: 'inline-citation' }
+          ]}
+        />
+      </section>
+
       <section className="chat-layout">
-        <h2 className="section-title">Chatbot Demo</h2>
+        <h2 className="section-title">See it in conversation</h2>
         <Chatbot />
       </section>
     </main>

--- a/src/components/Chatbot.tsx
+++ b/src/components/Chatbot.tsx
@@ -18,33 +18,33 @@ const seedMessages: Message[] = [
   {
     id: '1',
     role: 'assistant',
-    name: 'Playwright MCP',
+    name: 'AI Elements Copilot',
     content:
-      "Hello! I can drive Playwright to collect structured accessibility snapshots so you don't have to parse screenshots. What workflow should we run today?"
+      'Hey! Need help scaffolding AI-native interfaces? I can walk you through the AI Elements registry and wire components into your app.'
   },
   {
     id: '2',
     role: 'user',
     name: 'You',
-    content: 'Navigate to the AI SDK UI chatbot docs and summarise the integration steps.'
+    content: 'I want a conversation layout with inline citations and a task timeline. Where should I start?'
   },
   {
     id: '3',
     role: 'assistant',
-    name: 'Playwright MCP',
-    content: 'Running Playwright navigation…',
+    name: 'AI Elements Copilot',
+    content: 'Inspecting component registry…',
     toolCall: {
-      name: 'playwright.navigate',
-      args: { url: 'https://sdk.vercel.ai/docs/ai-sdk-ui/chatbot' },
-      result: 'Visited documentation page and captured accessibility tree.'
+      name: 'ai-elements.lookup',
+      args: { components: ['conversation', 'inline-citation', 'task'] },
+      result: 'Found conversation, inline-citation, and task components with live previews.'
     }
   },
   {
     id: '4',
     role: 'assistant',
-    name: 'Playwright MCP',
+    name: 'AI Elements Copilot',
     content:
-      'The docs recommend rendering the <Chat /> component, wiring a message array, and streaming responses through the AI SDK UI channel APIs.'
+      'Start by rendering <Conversation /> with your message stream, wrap insights with <InlineCitation />, and visualise progress via the <Task /> timeline.'
   }
 ];
 
@@ -54,7 +54,7 @@ export function Chatbot() {
 
   const placeholder = useMemo(
     () =>
-      'Ask the MCP server to explore, capture snapshots, or execute deterministic browser actions…',
+      'Ask the copilot to assemble UI flows, suggest components, or orchestrate AI tool calls…',
     []
   );
 
@@ -74,9 +74,9 @@ export function Chatbot() {
     const assistantMessage: Message = {
       id: `${Date.now()}-assistant`,
       role: 'assistant',
-      name: 'Playwright MCP',
+      name: 'AI Elements Copilot',
       content:
-        'This demo response is simulated. Hook this UI to your MCP server stream to make it conversational!'
+        'Great choice! Connect your data source to <Conversation /> and progressively hydrate messages as your model streams updates.'
     };
 
     setMessages((prev) => [...prev, userMessage, assistantMessage]);
@@ -86,11 +86,12 @@ export function Chatbot() {
   return (
     <div className="chat-panel">
       <header className="chat-header">
-        <div className="avatar avatar-assistant">M</div>
+        <div className="avatar avatar-assistant">A</div>
         <div>
-          <div className="chat-title">Model Context Protocol Chat</div>
+          <div className="chat-title">AI Elements Copilot</div>
           <p className="chat-description">
-            Showcase of an AI SDK UI chatbot panel wired for deterministic tool usage with Playwright.
+            Follow along as the copilot assembles components, previews tool outputs, and keeps specs in sync
+            with the AI Elements registry.
           </p>
         </div>
       </header>

--- a/src/components/ComponentList.tsx
+++ b/src/components/ComponentList.tsx
@@ -1,0 +1,28 @@
+type Component = {
+  name: string;
+  path: string;
+};
+
+type ComponentListProps = {
+  components: Component[];
+};
+
+const DOCS_BASE_URL = 'https://ai-elements.vercel.app/components/';
+
+export function ComponentList({ components }: ComponentListProps) {
+  return (
+    <ul className="component-list" role="list">
+      {components.map((component) => (
+        <li key={component.path} className="component-item" role="listitem">
+          <div>
+            <span className="component-name">{component.name}</span>
+            <span className="component-path">{component.path}</span>
+          </div>
+          <a href={`${DOCS_BASE_URL}${component.path}`} aria-label={`View ${component.name} component`}>
+            View docs
+          </a>
+        </li>
+      ))}
+    </ul>
+  );
+}

--- a/src/styles.css
+++ b/src/styles.css
@@ -24,20 +24,85 @@ a {
 main {
   max-width: 1080px;
   margin: 0 auto;
-  padding: 3rem 1.5rem 4rem;
+  padding: 3.5rem 1.5rem 4rem;
 }
 
 h1 {
-  font-size: clamp(2rem, 5vw, 3rem);
-  margin-bottom: 0.75rem;
+  font-size: clamp(2.5rem, 6vw, 3.75rem);
+  margin: 0.5rem 0 1rem;
   font-weight: 700;
   color: #0f172a;
 }
 
 .lead {
-  font-size: 1.125rem;
+  font-size: 1.15rem;
   color: #475569;
   margin-bottom: 2.5rem;
+  max-width: 720px;
+}
+
+.hero {
+  display: flex;
+  flex-direction: column;
+  gap: 1rem;
+}
+
+.eyebrow {
+  font-size: 0.85rem;
+  font-weight: 600;
+  letter-spacing: 0.08em;
+  text-transform: uppercase;
+  color: #2563eb;
+}
+
+.hero-actions {
+  display: flex;
+  gap: 1rem;
+  flex-wrap: wrap;
+}
+
+.button {
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  padding: 0.75rem 1.4rem;
+  border-radius: 999px;
+  background: #0f172a;
+  color: #fff;
+  font-weight: 600;
+  text-decoration: none;
+  transition: transform 150ms ease, box-shadow 150ms ease, background 150ms ease;
+  box-shadow: 0 14px 30px -20px rgba(15, 23, 42, 0.65);
+}
+
+.button:hover {
+  transform: translateY(-1px);
+  box-shadow: 0 18px 36px -20px rgba(15, 23, 42, 0.6);
+}
+
+.button-secondary {
+  background: #f8fafc;
+  color: #0f172a;
+  border: 1px solid rgba(15, 23, 42, 0.12);
+}
+
+.button-secondary:hover {
+  background: #e2e8f0;
+}
+
+.installation pre {
+  background: #0f172a;
+  color: #e2e8f0;
+  padding: 1rem 1.25rem;
+  border-radius: 1rem;
+  margin: 1rem 0 0;
+  overflow-x: auto;
+  font-family: 'JetBrains Mono', 'SFMono-Regular', ui-monospace, SFMono-Regular, Menlo, Monaco, Consolas,
+    'Liberation Mono', 'Courier New', monospace;
+}
+
+.installation code {
+  font-size: 0.95rem;
 }
 
 .grid {
@@ -62,6 +127,74 @@ h1 {
   margin-top: 3rem;
   margin-bottom: 1rem;
   color: #0f172a;
+}
+
+.catalogue {
+  margin-top: 3.5rem;
+}
+
+.catalogue-copy {
+  color: #475569;
+  max-width: 720px;
+  margin-bottom: 1.5rem;
+}
+
+.component-list {
+  list-style: none;
+  margin: 0;
+  padding: 0;
+  display: grid;
+  gap: 0.85rem;
+}
+
+@media (min-width: 640px) {
+  .component-list {
+    grid-template-columns: repeat(2, minmax(0, 1fr));
+  }
+}
+
+@media (min-width: 1024px) {
+  .component-list {
+    grid-template-columns: repeat(3, minmax(0, 1fr));
+  }
+}
+
+.component-item {
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  gap: 1rem;
+  background: rgba(15, 23, 42, 0.03);
+  border: 1px solid rgba(15, 23, 42, 0.07);
+  border-radius: 1rem;
+  padding: 0.95rem 1.1rem;
+}
+
+.component-item div {
+  min-width: 0;
+}
+
+.component-item a {
+  font-weight: 600;
+  color: #2563eb;
+  text-decoration: none;
+  flex-shrink: 0;
+}
+
+.component-item a:hover {
+  text-decoration: underline;
+}
+
+.component-name {
+  display: block;
+  font-weight: 600;
+  color: #0f172a;
+}
+
+.component-path {
+  display: block;
+  font-size: 0.85rem;
+  color: #64748b;
 }
 
 .card {


### PR DESCRIPTION
## Summary
- refactor the landing experience to introduce the AI Elements registry, installation command, and key benefits
- list the available components with quick links to their documentation using a new ComponentList component
- refresh the chatbot demo copy and styling to align with the AI Elements copilot narrative

## Testing
- npm install *(fails: npm registry returned 403 Forbidden)*

------
https://chatgpt.com/codex/tasks/task_b_68e1a980b3dc8332b360ab589538dc4b