### PR TITLE
Document agent testing loop and ignore build artifacts

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,22 @@
+# Dependencies
+node_modules/
+
+# Build output
+.next/
+out/
+
+# Env files
+.env*
+
+# Logs
+npm-debug.log*
+yarn-debug.log*
+yarn-error.log*
+pnpm-debug.log*
+
+# Editor directories and files
+.DS_Store
+.idea/
+.vscode/
+*.swp
+

--- a/README.md
+++ b/README.md
@@ -62,6 +62,23 @@ is structured so you can replace the mocked implementation with your own streami
 - Extend the `useChatManager` hook to call vector search, tool executors, or evaluation harnesses.
 - Replace the CSS tokens in `app/globals.css` with Tailwind or your design system of choice.
 
+## Agent testing workflow
+
+To keep prompt and configuration changes grounded in measurable impact, adopt an iterative
+testing loop:
+
+1. **Define the target behaviour** by writing automated or scriptable test cases before you
+   touch prompts or code. Cover core user journeys, stress cases, and likely failure modes so
+   expectations are explicit.
+2. **Run the suite and inspect the failures** to identify the biggest behavioural gaps.
+   Triage failed scenarios by user or business impact to decide what to tackle first.
+3. **Tweak one lever at a time**—prompt copy, retrieval settings, safety guardrails—and record
+   each experiment so you know exactly which change drove the improvement.
+4. **Re-run the tests after every adjustment**. Iterate until the entire suite passes so you can
+   ship with confidence.
+5. **Integrate the suite into CI/CD when possible** to automatically catch regressions as the
+   agent evolves.
+
 ## License
 
 MIT


### PR DESCRIPTION
## Summary
- add a repository .gitignore to exclude dependencies, build output, environment files, and editor artifacts
- document an iterative agent testing workflow in the README for future contributors

## Testing
- not run (documentation only)


------
https://chatgpt.com/codex/tasks/task_b_68e2c8cfe81483328e43c9ded926d572