### PR TITLE
Add Redis and Groq integration examples

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -1,0 +1,6 @@
+# Upstash Redis credentials
+UPSTASH_REDIS_REST_URL="https://<your-upstash-endpoint>"
+UPSTASH_REDIS_REST_TOKEN="<your-upstash-token>"
+
+# Groq API key for the Groq SDK and streaming examples
+GROQ_API_KEY="sk_groq_..."

--- a/.gitignore
+++ b/.gitignore
@@ -7,6 +7,7 @@ out/
 
 # Env files
 .env*
+!.env.example
 
 # Logs
 npm-debug.log*

--- a/README.md
+++ b/README.md
@@ -21,6 +21,20 @@ npm run dev
 
 The development server runs on [http://localhost:3000](http://localhost:3000).
 
+### Environment variables
+
+Copy `.env.example` to `.env.local` and fill in your Upstash Redis and Groq credentials before running any API routes.
+
+```bash
+cp .env.example .env.local
+```
+
+| Variable | Description |
+| --- | --- |
+| `UPSTASH_REDIS_REST_URL` | REST endpoint for your Upstash Redis database. |
+| `UPSTASH_REDIS_REST_TOKEN` | REST token for the Upstash Redis database. |
+| `GROQ_API_KEY` | API key used by the Groq SDK and streaming examples. |
+
 ## Project structure
 
 ```
@@ -55,6 +69,57 @@ The development server runs on [http://localhost:3000](http://localhost:3000).
 The `/api/chat` route expects the same schema used by Vercel AI Elements: an array of `{ id, role, content }
 messages along with persona and temperature metadata. It returns a single assistant message by default, but
 is structured so you can replace the mocked implementation with your own streaming handler.
+
+### Upstash Redis example route
+
+The App Router exposes `POST /api/upstash`, which demonstrates how to read data from Upstash Redis using the official SDK.
+
+```ts
+// app/api/upstash/route.ts
+import { Redis } from '@upstash/redis';
+import { NextResponse } from 'next/server';
+
+const redis = Redis.fromEnv();
+
+export async function POST() {
+  const result = await redis.get('item');
+  return NextResponse.json({ result });
+}
+```
+
+### Groq integration examples
+
+- `pages/api/groq-test.js` adds a Pages Router endpoint that exercises the Groq SDK's Chat Completions API.
+- `scripts/groq-stream.ts` shows how to stream text responses from Groq models via the `@ai-sdk/groq` provider.
+
+Run the streaming demo with your API key by executing the script via `ts-node` or `tsx`:
+
+```bash
+npx tsx scripts/groq-stream.ts
+```
+
+You can also make raw HTTP requests with cURL by swapping in your key and prompt:
+
+```bash
+curl "https://api.groq.com/openai/v1/chat/completions" \
+  -X POST \
+  -H "Content-Type: application/json" \
+  -H "Authorization: Bearer <GROQ_API_KEY>" \
+  -d '{
+        "messages": [
+          {
+            "role": "user",
+            "content": "Why is fast inference so important for AI applications?"
+          }
+        ],
+        "model": "qwen-qwq-32b",
+        "temperature": 0.6,
+        "max_completion_tokens": 32768,
+        "top_p": 0.95,
+        "stream": true,
+        "stop": null
+      }'
+```
 
 ## Customisation roadmap
 

--- a/app/api/upstash/route.ts
+++ b/app/api/upstash/route.ts
@@ -1,0 +1,21 @@
+import { Redis } from '@upstash/redis';
+import { NextResponse } from 'next/server';
+
+const redis = Redis.fromEnv();
+
+export const runtime = 'edge';
+
+export async function POST() {
+  try {
+    const result = await redis.get('item');
+
+    return NextResponse.json({ result });
+  } catch (error) {
+    console.error('Failed to fetch item from Redis:', error);
+
+    return NextResponse.json(
+      { error: 'Unable to fetch item from Redis.' },
+      { status: 500 },
+    );
+  }
+}

--- a/next-env.d.ts
+++ b/next-env.d.ts
@@ -1,5 +1,6 @@
 /// <reference types="next" />
 /// <reference types="next/image-types/global" />
+/// <reference types="next/navigation-types/compat/navigation" />
 
 // NOTE: This file should not be edited
 // see https://nextjs.org/docs/basic-features/typescript for more information.

--- a/package.json
+++ b/package.json
@@ -6,9 +6,14 @@
     "dev": "next dev",
     "build": "next build",
     "start": "next start",
-    "lint": "next lint"
+    "lint": "next lint",
+    "groq:stream": "tsx scripts/groq-stream.ts"
   },
   "dependencies": {
+    "@upstash/redis": "^1.32.0",
+    "@ai-sdk/groq": "^0.0.30",
+    "ai": "^3.3.31",
+    "groq-sdk": "^0.5.0",
     "next": "14.2.5",
     "react": "^18.3.1",
     "react-dom": "^18.3.1"

--- a/pages/api/groq-test.js
+++ b/pages/api/groq-test.js
@@ -1,0 +1,30 @@
+import { Groq } from 'groq-sdk';
+
+export default async function handler(req, res) {
+  if (req.method !== 'GET' && req.method !== 'POST') {
+    res.setHeader('Allow', ['GET', 'POST']);
+    return res.status(405).json({ error: 'Method Not Allowed' });
+  }
+
+  const apiKey = process.env.GROQ_API_KEY;
+
+  if (!apiKey) {
+    return res.status(500).json({ error: 'Missing GROQ_API_KEY environment variable.' });
+  }
+
+  const groq = new Groq({ apiKey });
+
+  try {
+    const response = await groq.chat.completions.create({
+      model: 'llama-3.3-70b-versatile',
+      messages: [
+        { role: 'user', content: 'Hello from Vercel!' },
+      ],
+    });
+
+    return res.status(200).json({ message: response.choices[0]?.message?.content ?? null });
+  } catch (error) {
+    const message = error instanceof Error ? error.message : 'Unknown error';
+    return res.status(500).json({ error: message });
+  }
+}

--- a/scripts/groq-stream.ts
+++ b/scripts/groq-stream.ts
@@ -1,0 +1,33 @@
+import { groq } from '@ai-sdk/groq';
+import { streamText } from 'ai';
+
+export async function main() {
+  const result = streamText({
+    model: groq('deepseek-r1-distill-llama-70b'),
+    prompt: 'Invent a new holiday and describe its traditions.',
+  });
+
+  for await (const textPart of result.textStream) {
+    process.stdout.write(textPart);
+  }
+}
+
+const isDirectExecution = (() => {
+  if (typeof process === 'undefined' || !process.argv?.[1]) {
+    return false;
+  }
+
+  try {
+    const executedPath = new URL(`file://${process.argv[1]}`).href;
+    return import.meta.url === executedPath;
+  } catch {
+    return false;
+  }
+})();
+
+if (isDirectExecution) {
+  main().catch((error) => {
+    console.error('Streaming request failed:', error);
+    process.exit(1);
+  });
+}


### PR DESCRIPTION
## Summary
- add an Upstash Redis edge API route and document the required environment variables
- introduce a Groq chat completion API endpoint plus a streaming CLI helper script
- expand the README with usage instructions, curl example, and an env template committed via .env.example

## Testing
- npm run lint *(fails: interactive Next.js ESLint configuration prompt in CI environment)*

------
https://chatgpt.com/codex/tasks/task_b_68e2cd7ed2108332a0819436e7f4f80c