### PR TITLE
Replace @ai-sdk/groq usage with groq-sdk streaming demo

### DIFF
--- a/README.md
+++ b/README.md
@@ -90,7 +90,7 @@ export async function POST() {
 ### Groq integration examples
 
 - `pages/api/groq-test.js` adds a Pages Router endpoint that exercises the Groq SDK's Chat Completions API.
-- `scripts/groq-stream.ts` shows how to stream text responses from Groq models via the `@ai-sdk/groq` provider.
+- `scripts/groq-stream.ts` shows how to stream text responses from Groq models via the official `groq-sdk`.
 
 Run the streaming demo with your API key by executing the script via `ts-node` or `tsx`:
 

--- a/package.json
+++ b/package.json
@@ -11,8 +11,6 @@
   },
   "dependencies": {
     "@upstash/redis": "^1.32.0",
-    "@ai-sdk/groq": "^0.0.30",
-    "ai": "^3.3.31",
     "groq-sdk": "^0.5.0",
     "next": "14.2.5",
     "react": "^18.3.1",

--- a/scripts/groq-stream.ts
+++ b/scripts/groq-stream.ts
@@ -1,14 +1,33 @@
-import { groq } from '@ai-sdk/groq';
-import { streamText } from 'ai';
+import Groq from 'groq-sdk';
 
 export async function main() {
-  const result = streamText({
-    model: groq('deepseek-r1-distill-llama-70b'),
-    prompt: 'Invent a new holiday and describe its traditions.',
+  const apiKey = process.env.GROQ_API_KEY;
+
+  if (!apiKey) {
+    throw new Error(
+      'GROQ_API_KEY environment variable is required to run this script.'
+    );
+  }
+
+  const client = new Groq({ apiKey });
+
+  const stream = await client.chat.completions.create({
+    model: 'deepseek-r1-distill-llama-70b',
+    stream: true,
+    messages: [
+      {
+        role: 'user',
+        content: 'Invent a new holiday and describe its traditions.',
+      },
+    ],
   });
 
-  for await (const textPart of result.textStream) {
-    process.stdout.write(textPart);
+  for await (const chunk of stream) {
+    const text = chunk.choices?.[0]?.delta?.content;
+
+    if (text) {
+      process.stdout.write(text);
+    }
   }
 }
 


### PR DESCRIPTION
## Summary
- remove the @ai-sdk/groq dependency that is not published at the requested version
- refactor the Groq streaming demo script to use the official groq-sdk directly
- update the README to describe the new streaming approach

## Testing
- npm install *(fails in sandbox: 403 Forbidden to registry.npmjs.org)*

------
https://chatgpt.com/codex/tasks/task_b_68e2d061726c8332901ec88a179592ad