### PR TITLE
Connect chat API to Groq completions

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -4,6 +4,7 @@ node_modules/
 # Build output
 .next/
 out/
+tsconfig.tsbuildinfo
 
 # Env files
 .env*

--- a/README.md
+++ b/README.md
@@ -67,8 +67,9 @@ cp .env.example .env.local
 ## API contract
 
 The `/api/chat` route expects the same schema used by Vercel AI Elements: an array of `{ id, role, content }
-messages along with persona and temperature metadata. It returns a single assistant message by default, but
-is structured so you can replace the mocked implementation with your own streaming handler.
+messages along with persona and temperature metadata. It proxies the request to Groq's Chat Completions API
+via the Vercel AI SDK conventions and returns the assistant's reply. You can extend the route to stream
+responses or enrich the payload with tool calls if your use case requires it.
 
 ### Upstash Redis example route
 
@@ -123,7 +124,8 @@ curl "https://api.groq.com/openai/v1/chat/completions" \
 
 ## Customisation roadmap
 
-- Swap the mock implementation in `app/api/chat/route.ts` with your preferred inference provider.
+- Extend the Groq-backed implementation in `app/api/chat/route.ts` with streaming, tool execution, or
+  retrieval-augmented prompts.
 - Extend the `useChatManager` hook to call vector search, tool executors, or evaluation harnesses.
 - Replace the CSS tokens in `app/globals.css` with Tailwind or your design system of choice.
 

--- a/app/api/chat/route.ts
+++ b/app/api/chat/route.ts
@@ -1,4 +1,5 @@
-import { NextRequest } from "next/server";
+import { NextRequest, NextResponse } from "next/server";
+import Groq from "groq-sdk";
 import type { ChatMessage } from "@/lib/chat/types";
 
 const personas: Record<string, string> = {
@@ -10,133 +11,92 @@ const personas: Record<string, string> = {
     "You are an AI researcher who summarises findings, compares techniques, and is explicit about assumptions."
 };
 
-export async function POST(req: NextRequest) {
-  const body = await req.json();
-  const messages: ChatMessage[] = body?.messages ?? [];
-  const persona = typeof body?.persona === "string" ? body.persona : "full-stack";
-  const temperature = typeof body?.temperature === "number" ? body.temperature : 0.6;
-  const draftSystemPrompt = typeof body?.systemPrompt === "string" ? body.systemPrompt : "";
+const MODEL_MAP: Record<string, string> = {
+  "llama-3.3-70b-versatile": "llama-3.3-70b-versatile",
+  "llama-3.1-70b-versatile": "llama-3.1-70b-versatile",
+  "llama-guard-3-8b": "llama-guard-3-8b"
+};
 
+const DEFAULT_MODEL = "llama-3.3-70b-versatile";
+
+const groq = process.env.GROQ_API_KEY ? new Groq({ apiKey: process.env.GROQ_API_KEY }) : null;
+
+interface ChatRequestBody {
+  messages?: ChatMessage[];
+  persona?: string;
+  temperature?: number;
+  systemPrompt?: string;
+  model?: string;
+}
+
+export async function POST(req: NextRequest) {
+  if (!groq) {
+    return NextResponse.json(
+      { error: "GROQ_API_KEY is not configured. Set it in your environment to enable chatting." },
+      { status: 500 }
+    );
+  }
+
+  const body = (await req.json()) as ChatRequestBody;
+  const messages = Array.isArray(body?.messages) ? body.messages : [];
+  const persona = typeof body?.persona === "string" ? body.persona : "full-stack";
+  const draftSystemPrompt = typeof body?.systemPrompt === "string" ? body.systemPrompt : "";
   const personaPrompt = personas[persona] ?? personas["full-stack"];
   const systemPrompt = [personaPrompt, draftSystemPrompt].filter(Boolean).join("\n\n");
+  const model = MODEL_MAP[body?.model ?? ""] ?? DEFAULT_MODEL;
+  const temperature = clamp(typeof body?.temperature === "number" ? body.temperature : 0.6, 0, 1);
 
-  const lastUserMessage = [...messages].reverse().find((message) => message.role === "user");
-  const userContent = lastUserMessage?.content?.trim();
+  const groqMessages = buildGroqMessages(messages, systemPrompt);
 
-  const replySections: string[] = [];
+  try {
+    const completion = await groq.chat.completions.create({
+      model,
+      temperature,
+      messages: groqMessages
+    });
+
+    const content = completion.choices?.[0]?.message?.content?.trim();
+
+    if (!content) {
+      throw new Error("Groq response did not include any content");
+    }
+
+    const assistantMessage: ChatMessage = {
+      id: crypto.randomUUID(),
+      role: "assistant",
+      content,
+      createdAt: new Date().toISOString(),
+      status: "complete",
+      metadata: {
+        model,
+        temperature
+      }
+    };
+
+    return NextResponse.json({ message: assistantMessage });
+  } catch (error) {
+    const message = error instanceof Error ? error.message : "Unknown error";
+    console.error("Groq chat request failed", error);
+
+    return NextResponse.json({ error: message }, { status: 502 });
+  }
+}
+
+function buildGroqMessages(messages: ChatMessage[], systemPrompt: string) {
+  const sanitized = messages
+    .filter((message) => (message.role === "user" || message.role === "assistant") && Boolean(message.content?.trim()))
+    .map((message) => ({
+      role: message.role,
+      content: message.content
+    }));
 
   if (systemPrompt) {
-    replySections.push(
-      `Persona context (temperature ${temperature.toFixed(2)}): ${systemPrompt}`
-    );
+    return [{ role: "system", content: systemPrompt }, ...sanitized];
   }
 
-  if (userContent) {
-    replySections.push(`You asked me to: ${userContent}`);
-  } else {
-    replySections.push(
-      "No user prompt was supplied. Ask me about product ideas, implementation plans, or debugging questions."
-    );
-  }
-
-  const conversationInsights = summariseConversation(messages);
-  if (conversationInsights) {
-    replySections.push(conversationInsights);
-  }
-
-  const suggestions = buildSuggestions(userContent);
-  if (suggestions.length > 0) {
-    replySections.push("Next steps:" + suggestions.map((item) => `\n• ${item}`).join(""));
-  }
-
-  const assistantMessage: ChatMessage = {
-    id: crypto.randomUUID(),
-    role: "assistant",
-    content: replySections.join("\n\n"),
-    createdAt: new Date().toISOString(),
-    status: "complete"
-  };
-
-  return new Response(JSON.stringify({ message: assistantMessage }), {
-    headers: {
-      "Content-Type": "application/json"
-    }
-  });
+  return sanitized;
 }
 
-function summariseConversation(messages: ChatMessage[]) {
-  if (!messages.length) {
-    return "";
-  }
-
-  const userTurns = messages.filter((message) => message.role === "user");
-  const assistantTurns = messages.filter((message) => message.role === "assistant");
-
-  const summaryParts: string[] = [];
-
-  if (userTurns.length > 0) {
-    summaryParts.push(
-      `User messages so far (${userTurns.length}): ${userTurns
-        .slice(-3)
-        .map((message) => truncate(message.content, 140))
-        .join(" | ")}`
-    );
-  }
-
-  if (assistantTurns.length > 0) {
-    summaryParts.push(
-      `Assistant replies so far (${assistantTurns.length}): ${assistantTurns
-        .slice(-3)
-        .map((message) => truncate(message.content, 140))
-        .join(" | ")}`
-    );
-  }
-
-  return summaryParts.join("\n");
-}
-
-function buildSuggestions(userContent?: string) {
-  if (!userContent) {
-    return [
-      "Share a product requirement, API contract, or error trace you want help with.",
-      "Switch persona in the toolbar to explore different viewpoints.",
-      "Draft a follow-up question to dig deeper into your topic."
-    ];
-  }
-
-  const lowered = userContent.toLowerCase();
-
-  if (lowered.includes("plan") || lowered.includes("architecture")) {
-    return [
-      "List the critical components and responsibilities you expect to build.",
-      "Highlight any third-party APIs or services that will be involved.",
-      "Ask for edge cases or failure scenarios you might be missing."
-    ];
-  }
-
-  if (lowered.includes("debug") || lowered.includes("error")) {
-    return [
-      "Paste the relevant stack trace or console output so I can inspect it.",
-      "Describe what you expected to happen and what actually occurred.",
-      "Explain the environment (local, staging, production) where the bug appears."
-    ];
-  }
-
-  if (lowered.includes("copy") || lowered.includes("marketing")) {
-    return [
-      "Clarify the audience you are targeting with this message.",
-      "Share the tone or brand guidelines you need to follow.",
-      "Specify the channel (landing page, onboarding email, release notes, etc.)."
-    ];
-  }
-
-  return [
-    "Request code snippets or pseudo-code to move faster.",
-    "Ask for test cases or telemetry you can add to validate the idea.",
-    "Invite the assistant to suggest how AI building blocks can elevate the experience."
-  ];
-}
-
-function truncate(value: string, length: number) {
-  return value.length > length ? `${value.slice(0, length - 1)}…` : value;
+function clamp(value: number, min: number, max: number) {
+  return Math.min(Math.max(value, min), max);
 }

--- a/components/chat/SystemToolbar.tsx
+++ b/components/chat/SystemToolbar.tsx
@@ -11,7 +11,11 @@ interface SystemToolbarProps {
   onPersonaChange: (persona: string) => void;
 }
 
-const MODELS = ["gpt-4o-mini", "gpt-4.1", "claude-3.5", "llama-3.1"];
+const MODELS = [
+  { value: "llama-3.3-70b-versatile", label: "Llama 3.3 70B (versatile)" },
+  { value: "llama-3.1-70b-versatile", label: "Llama 3.1 70B (versatile)" },
+  { value: "llama-guard-3-8b", label: "Llama Guard 3 8B" }
+];
 const PERSONAS = [
   { value: "full-stack", label: "Full-stack engineer" },
   { value: "product-designer", label: "Product designer" },
@@ -53,8 +57,8 @@ export function SystemToolbar({
         Model
         <select value={settings.model} onChange={(event) => onSettingsChange({ model: event.target.value })}>
           {MODELS.map((model) => (
-            <option key={model} value={model}>
-              {model}
+            <option key={model.value} value={model.value}>
+              {model.label}
             </option>
           ))}
         </select>

--- a/lib/chat/useChatManager.ts
+++ b/lib/chat/useChatManager.ts
@@ -31,7 +31,7 @@ const STORAGE_KEY = "ai-elements-chatbot";
 const DEFAULT_SETTINGS: ChatSettings = {
   persona: "full-stack",
   temperature: 0.6,
-  model: "gpt-4o-mini"
+  model: "llama-3.3-70b-versatile"
 };
 
 interface UseChatManagerResult {
@@ -220,11 +220,15 @@ export function useChatManager(): UseChatManagerResult {
           })
         });
 
-        if (!response.ok) {
-          throw new Error(`Request failed with status ${response.status}`);
+        const payload = (await response.json().catch(() => null)) as
+          | { message?: ChatMessage; error?: string }
+          | null;
+
+        if (!response.ok || !payload?.message) {
+          const errorMessage = payload?.error || `Request failed with status ${response.status}`;
+          throw new Error(errorMessage);
         }
 
-        const payload = (await response.json()) as { message: ChatMessage };
         const assistantMessage = payload.message;
 
         const mergedMessages = nextMessages.map((message): ChatMessage => {
@@ -240,12 +244,14 @@ export function useChatManager(): UseChatManagerResult {
         pushMessages(conversationId, mergedMessages);
       } catch (error) {
         console.error("Chat request failed", error);
+        const failureReason =
+          error instanceof Error ? error.message : "Request failed. Try again.";
         const erroredMessages = nextMessages.map((message): ChatMessage => {
           if (message.id === assistantPlaceholder.id) {
             const errorMessage: ChatMessage = {
               ...message,
               status: "error",
-              content: "Request failed. Try again."
+              content: failureReason
             };
             return errorMessage;
           }
@@ -295,11 +301,15 @@ export function useChatManager(): UseChatManagerResult {
           })
         });
 
-        if (!response.ok) {
-          throw new Error(`Request failed with status ${response.status}`);
+        const payload = (await response.json().catch(() => null)) as
+          | { message?: ChatMessage; error?: string }
+          | null;
+
+        if (!response.ok || !payload?.message) {
+          const errorMessage = payload?.error || `Request failed with status ${response.status}`;
+          throw new Error(errorMessage);
         }
 
-        const payload = (await response.json()) as { message: ChatMessage };
         const assistantMessage = payload.message;
 
         const mergedMessages = nextMessages.map((message): ChatMessage => {
@@ -315,12 +325,14 @@ export function useChatManager(): UseChatManagerResult {
         pushMessages(conversationId, mergedMessages);
       } catch (error) {
         console.error("Failed to regenerate message", error);
+        const failureReason =
+          error instanceof Error ? error.message : "Regeneration failed. Try again.";
         const erroredMessages = nextMessages.map((message): ChatMessage => {
           if (message.id === updatedPlaceholder.id) {
             const errorMessage: ChatMessage = {
               ...message,
               status: "error",
-              content: "Regeneration failed. Try again."
+              content: failureReason
             };
             return errorMessage;
           }

--- a/types/external.d.ts
+++ b/types/external.d.ts
@@ -1,0 +1,2 @@
+declare module "groq-sdk";
+declare module "@upstash/redis";


### PR DESCRIPTION
## Summary
- replace the mocked chat endpoint with a Groq-backed request that honours persona prompts and model selection
- tighten the chat manager to surface server-side errors and default to Groq-friendly models in the UI
- refresh supporting docs, toolbar options, ignore rules, and module declarations for the Groq integration

## Testing
- npx tsc --noEmit

------
https://chatgpt.com/codex/tasks/task_b_68e2d2aa80e0833286b729bb7a04a620