### PR TITLE
Connect chat route to Groq and guard composer submissions

### DIFF
--- a/app/api/chat/route.ts
+++ b/app/api/chat/route.ts
@@ -1,4 +1,5 @@
 import { NextRequest } from "next/server";
+import Groq from "groq-sdk";
 import type { ChatMessage } from "@/lib/chat/types";
 
 const personas: Record<string, string> = {
@@ -10,133 +11,120 @@ const personas: Record<string, string> = {
     "You are an AI researcher who summarises findings, compares techniques, and is explicit about assumptions."
 };
 
+const DEFAULT_MODEL = "llama-3.3-70b-versatile";
+
+let cachedGroqClient: Groq | null = null;
+
+function getGroqClient() {
+  if (cachedGroqClient) {
+    return cachedGroqClient;
+  }
+  const apiKey = process.env.GROQ_API_KEY;
+  if (!apiKey) {
+    throw new Error("Missing GROQ_API_KEY environment variable.");
+  }
+  cachedGroqClient = new Groq({ apiKey });
+  return cachedGroqClient;
+}
+
 export async function POST(req: NextRequest) {
-  const body = await req.json();
-  const messages: ChatMessage[] = body?.messages ?? [];
-  const persona = typeof body?.persona === "string" ? body.persona : "full-stack";
-  const temperature = typeof body?.temperature === "number" ? body.temperature : 0.6;
-  const draftSystemPrompt = typeof body?.systemPrompt === "string" ? body.systemPrompt : "";
+  try {
+    const body = await req.json();
+    const messages: ChatMessage[] = Array.isArray(body?.messages) ? body.messages : [];
+    const persona = typeof body?.persona === "string" ? body.persona : "full-stack";
+    const temperatureValue = typeof body?.temperature === "number" ? body.temperature : 0.6;
+    const draftSystemPrompt = typeof body?.systemPrompt === "string" ? body.systemPrompt : "";
+    const requestedModel = typeof body?.model === "string" ? body.model.trim() : "";
 
-  const personaPrompt = personas[persona] ?? personas["full-stack"];
-  const systemPrompt = [personaPrompt, draftSystemPrompt].filter(Boolean).join("\n\n");
+    const model = requestedModel || DEFAULT_MODEL;
+    const personaPrompt = personas[persona] ?? personas["full-stack"];
+    const systemPrompt = [personaPrompt, draftSystemPrompt].filter(Boolean).join("\n\n");
 
-  const lastUserMessage = [...messages].reverse().find((message) => message.role === "user");
-  const userContent = lastUserMessage?.content?.trim();
+    const history = buildChatHistory(messages, systemPrompt);
+    if (history.length === 0) {
+      return new Response(
+        JSON.stringify({
+          message: createAssistantMessage(
+            "I need a prompt to get started. Ask about a product idea, architecture decision, or debugging problem."
+          )
+        }),
+        {
+          headers: { "Content-Type": "application/json" }
+        }
+      );
+    }
 
-  const replySections: string[] = [];
+    const groq = getGroqClient();
+    const completion = await groq.chat.completions.create({
+      model,
+      temperature: clamp(temperatureValue, 0, 2),
+      messages: history
+    });
+
+    const content = completion.choices?.[0]?.message?.content?.trim();
+
+    if (!content) {
+      throw new Error("Groq response did not include assistant content.");
+    }
+
+    const assistantMessage: ChatMessage = {
+      id: crypto.randomUUID(),
+      role: "assistant",
+      content,
+      createdAt: new Date().toISOString(),
+      status: "complete"
+    };
+
+    return new Response(JSON.stringify({ message: assistantMessage }), {
+      headers: {
+        "Content-Type": "application/json"
+      }
+    });
+  } catch (error) {
+    console.error("Chat route failed", error);
+    const message =
+      error instanceof Error ? error.message : "Unexpected error while fetching assistant response.";
+    return new Response(JSON.stringify({ error: message }), {
+      status: 500,
+      headers: { "Content-Type": "application/json" }
+    });
+  }
+}
+
+function buildChatHistory(messages: ChatMessage[], systemPrompt: string) {
+  const history = messages
+    .filter((message) =>
+      message && typeof message.content === "string" && message.content.trim() && message.role !== "tool"
+    )
+    .map((message) => ({
+      role: mapRole(message.role),
+      content: message.content.trim()
+    }));
 
   if (systemPrompt) {
-    replySections.push(
-      `Persona context (temperature ${temperature.toFixed(2)}): ${systemPrompt}`
-    );
+    history.unshift({ role: "system", content: systemPrompt });
   }
 
-  if (userContent) {
-    replySections.push(`You asked me to: ${userContent}`);
-  } else {
-    replySections.push(
-      "No user prompt was supplied. Ask me about product ideas, implementation plans, or debugging questions."
-    );
-  }
+  return history;
+}
 
-  const conversationInsights = summariseConversation(messages);
-  if (conversationInsights) {
-    replySections.push(conversationInsights);
+function mapRole(role: ChatMessage["role"]) {
+  if (role === "assistant" || role === "system" || role === "user") {
+    return role;
   }
+  return "user";
+}
 
-  const suggestions = buildSuggestions(userContent);
-  if (suggestions.length > 0) {
-    replySections.push("Next steps:" + suggestions.map((item) => `\n• ${item}`).join(""));
-  }
+function clamp(value: number, min: number, max: number) {
+  return Math.min(Math.max(value, min), max);
+}
 
-  const assistantMessage: ChatMessage = {
+function createAssistantMessage(content: string): ChatMessage {
+  return {
     id: crypto.randomUUID(),
     role: "assistant",
-    content: replySections.join("\n\n"),
+    content,
     createdAt: new Date().toISOString(),
     status: "complete"
   };
-
-  return new Response(JSON.stringify({ message: assistantMessage }), {
-    headers: {
-      "Content-Type": "application/json"
-    }
-  });
-}
-
-function summariseConversation(messages: ChatMessage[]) {
-  if (!messages.length) {
-    return "";
-  }
-
-  const userTurns = messages.filter((message) => message.role === "user");
-  const assistantTurns = messages.filter((message) => message.role === "assistant");
-
-  const summaryParts: string[] = [];
-
-  if (userTurns.length > 0) {
-    summaryParts.push(
-      `User messages so far (${userTurns.length}): ${userTurns
-        .slice(-3)
-        .map((message) => truncate(message.content, 140))
-        .join(" | ")}`
-    );
-  }
-
-  if (assistantTurns.length > 0) {
-    summaryParts.push(
-      `Assistant replies so far (${assistantTurns.length}): ${assistantTurns
-        .slice(-3)
-        .map((message) => truncate(message.content, 140))
-        .join(" | ")}`
-    );
-  }
-
-  return summaryParts.join("\n");
-}
-
-function buildSuggestions(userContent?: string) {
-  if (!userContent) {
-    return [
-      "Share a product requirement, API contract, or error trace you want help with.",
-      "Switch persona in the toolbar to explore different viewpoints.",
-      "Draft a follow-up question to dig deeper into your topic."
-    ];
-  }
-
-  const lowered = userContent.toLowerCase();
-
-  if (lowered.includes("plan") || lowered.includes("architecture")) {
-    return [
-      "List the critical components and responsibilities you expect to build.",
-      "Highlight any third-party APIs or services that will be involved.",
-      "Ask for edge cases or failure scenarios you might be missing."
-    ];
-  }
-
-  if (lowered.includes("debug") || lowered.includes("error")) {
-    return [
-      "Paste the relevant stack trace or console output so I can inspect it.",
-      "Describe what you expected to happen and what actually occurred.",
-      "Explain the environment (local, staging, production) where the bug appears."
-    ];
-  }
-
-  if (lowered.includes("copy") || lowered.includes("marketing")) {
-    return [
-      "Clarify the audience you are targeting with this message.",
-      "Share the tone or brand guidelines you need to follow.",
-      "Specify the channel (landing page, onboarding email, release notes, etc.)."
-    ];
-  }
-
-  return [
-    "Request code snippets or pseudo-code to move faster.",
-    "Ask for test cases or telemetry you can add to validate the idea.",
-    "Invite the assistant to suggest how AI building blocks can elevate the experience."
-  ];
-}
-
-function truncate(value: string, length: number) {
-  return value.length > length ? `${value.slice(0, length - 1)}…` : value;
 }

--- a/components/chat/MessageComposer.tsx
+++ b/components/chat/MessageComposer.tsx
@@ -14,6 +14,9 @@ export function MessageComposer({ placeholder, isSending, onSubmit }: MessageCom
   const handleSubmit = useCallback(
     (event: FormEvent<HTMLFormElement>) => {
       event.preventDefault();
+      if (isSending) {
+        return;
+      }
       const trimmed = value.trim();
       if (!trimmed) {
         return;
@@ -21,7 +24,7 @@ export function MessageComposer({ placeholder, isSending, onSubmit }: MessageCom
       onSubmit(trimmed);
       setValue("");
     },
-    [onSubmit, value]
+    [isSending, onSubmit, value]
   );
 
   return (
@@ -30,7 +33,12 @@ export function MessageComposer({ placeholder, isSending, onSubmit }: MessageCom
         <span>Shift+Enter for newline</span>
         <span>{value.length} characters</span>
       </div>
-      <form onSubmit={handleSubmit}>
+      {isSending ? (
+        <p role="status" aria-live="polite" className="chat-status">
+          Assistant is responding…
+        </p>
+      ) : null}
+      <form onSubmit={handleSubmit} aria-busy={isSending}>
         <textarea
           value={value}
           placeholder={placeholder}
@@ -38,6 +46,9 @@ export function MessageComposer({ placeholder, isSending, onSubmit }: MessageCom
           onKeyDown={(event) => {
             if (event.key === "Enter" && !event.shiftKey) {
               event.preventDefault();
+              if (isSending) {
+                return;
+              }
               const trimmed = value.trim();
               if (trimmed) {
                 onSubmit(trimmed);
@@ -45,8 +56,9 @@ export function MessageComposer({ placeholder, isSending, onSubmit }: MessageCom
               }
             }
           }}
+          aria-disabled={isSending}
         />
-        <button type="submit" disabled={isSending}>
+        <button type="submit" disabled={isSending} aria-disabled={isSending}>
           {isSending ? "Sending" : "Send"}
         </button>
       </form>

--- a/components/chat/__tests__/MessageComposer.test.tsx
+++ b/components/chat/__tests__/MessageComposer.test.tsx
@@ -1,0 +1,54 @@
+import { fireEvent, render, screen } from "@testing-library/react";
+import userEvent from "@testing-library/user-event";
+import { vi } from "vitest";
+
+import { MessageComposer } from "../MessageComposer";
+
+describe("MessageComposer", () => {
+  it("submits trimmed value when allowed", async () => {
+    const handleSubmit = vi.fn();
+    const user = userEvent.setup();
+
+    render(
+      <MessageComposer
+        isSending={false}
+        placeholder="Type here"
+        onSubmit={handleSubmit}
+      />
+    );
+
+    const textarea = screen.getByPlaceholderText("Type here");
+    await user.type(textarea, "Hello world");
+    await user.keyboard("{Enter}");
+
+    expect(handleSubmit).toHaveBeenCalledWith("Hello world");
+  });
+
+  it("blocks submit interactions while sending", async () => {
+    const handleSubmit = vi.fn();
+    const user = userEvent.setup();
+
+    render(
+      <MessageComposer
+        isSending
+        placeholder="Compose"
+        onSubmit={handleSubmit}
+      />
+    );
+
+    const textarea = screen.getByPlaceholderText("Compose");
+    await user.type(textarea, "Pending message");
+
+    await user.keyboard("{Enter}");
+    expect(handleSubmit).not.toHaveBeenCalled();
+
+    const form = textarea.closest("form");
+    expect(form).toBeTruthy();
+
+    if (form) {
+      fireEvent.submit(form);
+    }
+
+    expect(handleSubmit).not.toHaveBeenCalled();
+  });
+});

--- a/package.json
+++ b/package.json
@@ -7,7 +7,8 @@
     "build": "next build",
     "start": "next start",
     "lint": "next lint",
-    "groq:stream": "tsx scripts/groq-stream.ts"
+    "groq:stream": "tsx scripts/groq-stream.ts",
+    "test": "vitest run"
   },
   "dependencies": {
     "@upstash/redis": "^1.32.0",
@@ -17,11 +18,16 @@
     "react-dom": "^18.3.1"
   },
   "devDependencies": {
+    "@testing-library/jest-dom": "^6.4.5",
+    "@testing-library/react": "^14.3.1",
+    "@testing-library/user-event": "^14.6.1",
     "@types/node": "^20.12.7",
     "@types/react": "^18.3.5",
     "@types/react-dom": "^18.3.0",
     "eslint": "^8.57.0",
     "eslint-config-next": "^14.2.5",
-    "typescript": "^5.4.5"
+    "jsdom": "^24.0.0",
+    "typescript": "^5.4.5",
+    "vitest": "^1.6.0"
   }
 }

--- a/vitest.config.ts
+++ b/vitest.config.ts
@@ -1,0 +1,9 @@
+import { defineConfig } from "vitest/config";
+
+export default defineConfig({
+  test: {
+    environment: "jsdom",
+    globals: true,
+    setupFiles: "./vitest.setup.ts"
+  }
+});

--- a/vitest.setup.ts
+++ b/vitest.setup.ts
@@ -1,0 +1,1 @@
+import "@testing-library/jest-dom/vitest";


### PR DESCRIPTION
## Summary
- replace the stubbed chat API with a Groq-backed implementation that forwards persona, system prompt, and temperature
- add submission guards and user feedback to the message composer plus regression tests ensuring sends are blocked mid-flight
- configure a Vitest test harness for component tests

## Testing
- `npm install` *(fails: registry responded 403 for @testing-library/jest-dom)*

------
https://chatgpt.com/codex/tasks/task_b_68e2dd4a7948833297919274cc390163