### PR TITLE
Prevent message composer submissions during send

### DIFF
--- a/components/chat/MessageComposer.test.tsx
+++ b/components/chat/MessageComposer.test.tsx
@@ -1,0 +1,47 @@
+import { fireEvent, render } from "@testing-library/react";
+import { describe, expect, it, vi } from "vitest";
+
+import { MessageComposer } from "./MessageComposer";
+
+describe("MessageComposer", () => {
+  it("ignores Enter submissions while sending", () => {
+    const handleSubmit = vi.fn();
+    const { getByPlaceholderText } = render(
+      <MessageComposer
+        placeholder="Type your message"
+        isSending={true}
+        onSubmit={handleSubmit}
+      />
+    );
+
+    const textarea = getByPlaceholderText("Type your message") as HTMLTextAreaElement;
+
+    fireEvent.change(textarea, { target: { value: "Hello world" } });
+    fireEvent.keyDown(textarea, { key: "Enter" });
+
+    expect(handleSubmit).not.toHaveBeenCalled();
+    expect(textarea.value).toBe("Hello world");
+  });
+
+  it("ignores form submissions while sending", () => {
+    const handleSubmit = vi.fn();
+    const { getByPlaceholderText } = render(
+      <MessageComposer
+        placeholder="Type another message"
+        isSending={true}
+        onSubmit={handleSubmit}
+      />
+    );
+
+    const textarea = getByPlaceholderText("Type another message") as HTMLTextAreaElement;
+    const form = textarea.closest("form");
+
+    expect(form).not.toBeNull();
+
+    fireEvent.change(textarea, { target: { value: "Queued message" } });
+    fireEvent.submit(form!);
+
+    expect(handleSubmit).not.toHaveBeenCalled();
+    expect(textarea.value).toBe("Queued message");
+  });
+});

--- a/components/chat/MessageComposer.tsx
+++ b/components/chat/MessageComposer.tsx
@@ -14,6 +14,9 @@ export function MessageComposer({ placeholder, isSending, onSubmit }: MessageCom
   const handleSubmit = useCallback(
     (event: FormEvent<HTMLFormElement>) => {
       event.preventDefault();
+      if (isSending) {
+        return;
+      }
       const trimmed = value.trim();
       if (!trimmed) {
         return;
@@ -21,7 +24,7 @@ export function MessageComposer({ placeholder, isSending, onSubmit }: MessageCom
       onSubmit(trimmed);
       setValue("");
     },
-    [onSubmit, value]
+    [isSending, onSubmit, value]
   );
 
   return (
@@ -38,6 +41,9 @@ export function MessageComposer({ placeholder, isSending, onSubmit }: MessageCom
           onKeyDown={(event) => {
             if (event.key === "Enter" && !event.shiftKey) {
               event.preventDefault();
+              if (isSending) {
+                return;
+              }
               const trimmed = value.trim();
               if (trimmed) {
                 onSubmit(trimmed);
@@ -49,6 +55,11 @@ export function MessageComposer({ placeholder, isSending, onSubmit }: MessageCom
         <button type="submit" disabled={isSending}>
           {isSending ? "Sending" : "Send"}
         </button>
+        {isSending ? (
+          <p className="chat-status" aria-live="polite">
+            Assistant is still responding...
+          </p>
+        ) : null}
       </form>
     </div>
   );

--- a/package.json
+++ b/package.json
@@ -7,6 +7,7 @@
     "build": "next build",
     "start": "next start",
     "lint": "next lint",
+    "test": "vitest",
     "groq:stream": "tsx scripts/groq-stream.ts"
   },
   "dependencies": {
@@ -20,8 +21,11 @@
     "@types/node": "^20.12.7",
     "@types/react": "^18.3.5",
     "@types/react-dom": "^18.3.0",
+    "@testing-library/react": "^14.2.1",
+    "jsdom": "^24.0.0",
     "eslint": "^8.57.0",
     "eslint-config-next": "^14.2.5",
-    "typescript": "^5.4.5"
+    "typescript": "^5.4.5",
+    "vitest": "^1.6.0"
   }
 }

--- a/vitest.config.ts
+++ b/vitest.config.ts
@@ -1,0 +1,7 @@
+import { defineConfig } from "vitest/config";
+
+export default defineConfig({
+  test: {
+    environment: "jsdom",
+  },
+});


### PR DESCRIPTION
## Summary
- block message composer submission handlers when a response is already being sent and show inline status feedback
- add a regression test covering Enter key and form submissions while the composer is sending
- configure Vitest and expose an npm test script for future component tests

## Testing
- npm test *(fails: vitest binary unavailable in this environment because dev dependencies could not be installed)*

------
https://chatgpt.com/codex/tasks/task_b_68e2de8010288332ad6d1c154d6212a7